### PR TITLE
Fix lighting HID descriptor for Windows

### DIFF
--- a/fw/src/config.h
+++ b/fw/src/config.h
@@ -13,11 +13,6 @@
 #define CFG_RGB_USB_VID   0x1209
 #define CFG_RGB_USB_PID   0xB210
 
-// The number of lamps that can be updated in a single LampMultiUpdateReport
-//
-// Range: [1, 8]
-#define CFG_RGB_MULTI_UPDATE_SIZE 2
-
 // The dimensions of the bounding box that contains all lights
 //
 // Range: [0, 2^31-1]

--- a/fw/src/include/hid/descriptor.h
+++ b/fw/src/include/hid/descriptor.h
@@ -22,6 +22,7 @@
 
 // Adds COUNT uint8 items of TYPE to the report with FLAGS
 #define HID_ITEM_UINT8(TYPE, COUNT, FLAGS)  \
+    HID_LOGICAL_MIN     (0),                \
     HID_LOGICAL_MAX_N   (UINT8_MAX, 2),     \
     HID_REPORT_SIZE     (8),                \
     HID_REPORT_COUNT    (COUNT),            \
@@ -29,6 +30,7 @@
 
 // Adds COUNT uint16 items of TYPE to the report with FLAGS
 #define HID_ITEM_UINT16(TYPE, COUNT, FLAGS) \
+    HID_LOGICAL_MIN     (0),                \
     HID_LOGICAL_MAX_N   (UINT16_MAX, 3),    \
     HID_REPORT_SIZE     (16),               \
     HID_REPORT_COUNT    (COUNT),            \
@@ -36,6 +38,7 @@
 
 // Adds COUNT int32 items of TYPE to the report with FLAGS
 #define HID_ITEM_INT32(TYPE, COUNT, FLAGS)  \
+    HID_LOGICAL_MIN     (0),                \
     HID_LOGICAL_MAX_N   (INT32_MAX, 3),     \
     HID_REPORT_SIZE     (32),               \
     HID_REPORT_COUNT    (COUNT),            \

--- a/fw/src/include/hid/lights/report.h
+++ b/fw/src/include/hid/lights/report.h
@@ -28,9 +28,7 @@
 #define HID_COLLECTION_LAMP_ARRAY \
     HID_USAGE_PAGE    (HID_USAGE_PAGE_LIGHTING), \
     HID_USAGE         (HID_USAGE_LIGHTING_LAMP_ARRAY), \
-    HID_COLLECTION    (HID_COLLECTION_APPLICATION), \
-        HID_LOGICAL_MIN     (0), \
-        HID_UNIT_EXPONENT   (0)
+    HID_COLLECTION    (HID_COLLECTION_APPLICATION)
 
 // -------------------------
 // LampArrayAttributesReport
@@ -73,11 +71,11 @@ struct __attribute__ ((packed)) LampArrayAttributesReport {
     HID_COLLECTION  (HID_COLLECTION_LOGICAL), \
         /* LampId */ \
         HID_USAGE         (HID_USAGE_LIGHTING_LAMP_ID), \
-        HID_ITEM_UINT8    (FEATURE, 1, HID_CONSTANT | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_ITEM_UINT16   (FEATURE, 1, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
     HID_COLLECTION_END
 
 struct __attribute__ ((packed)) LampAttributesRequestReport {
-    uint8_t lamp_id;
+    uint16_t lamp_id;
 };
 
 // ----------------------------
@@ -89,7 +87,7 @@ struct __attribute__ ((packed)) LampAttributesRequestReport {
     HID_COLLECTION  (HID_COLLECTION_LOGICAL), \
         /* LampId */ \
         HID_USAGE         (HID_USAGE_LIGHTING_LAMP_ID), \
-        HID_ITEM_UINT8    (FEATURE, 1, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_ITEM_UINT16   (FEATURE, 1, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
         /* PositionXInMicrometers, PositionYInMicrometers, PositionZInMicrometers */ \
         /* UpdateLatencyInMicroseconds */ \
         /* LampPurposes */ \
@@ -112,18 +110,18 @@ struct __attribute__ ((packed)) LampAttributesRequestReport {
     HID_COLLECTION_END
 
 struct __attribute__ ((packed)) LampAttributesResponseReport {
-    uint8_t lamp_id;
-    int32_t position_x;
-    int32_t position_y;
-    int32_t position_z;
-    int32_t update_latency;
-    int32_t lamp_purpose;
-    uint8_t red_level_count;
-    uint8_t green_level_count;
-    uint8_t blue_level_count;
-    uint8_t intensity_level_count;
-    uint8_t is_programmable;
-    uint8_t input_binding;
+    uint16_t lamp_id;
+    int32_t  position_x;
+    int32_t  position_y;
+    int32_t  position_z;
+    int32_t  update_latency;
+    int32_t  lamp_purpose;
+    uint8_t  red_level_count;
+    uint8_t  green_level_count;
+    uint8_t  blue_level_count;
+    uint8_t  intensity_level_count;
+    uint8_t  is_programmable;
+    uint8_t  input_binding;
 };
 
 // ---------------------
@@ -136,16 +134,17 @@ struct __attribute__ ((packed)) LampAttributesResponseReport {
     HID_COLLECTION  (HID_COLLECTION_LOGICAL), \
         /* LampCount */ \
         HID_USAGE         (HID_USAGE_LIGHTING_LAMP_COUNT), \
+        HID_LOGICAL_MIN   (0), \
         HID_LOGICAL_MAX   (LAMP_MULTI_UPDATE_BATCH_SIZE), \
         HID_REPORT_SIZE   (8), \
         HID_REPORT_COUNT  (1), \
-        HID_OUTPUT        (HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_FEATURE       (HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
         /* LampUpdateFlags */ \
         HID_USAGE         (HID_USAGE_LIGHTING_LAMP_UPDATE_FLAGS), \
-        HID_ITEM_UINT16   (OUTPUT, 1, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_ITEM_UINT8    (FEATURE, 1, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
         /* LampId Slots */ \
         HID_USAGE         (HID_USAGE_LIGHTING_LAMP_ID), \
-        HID_ITEM_UINT8    (OUTPUT, LAMP_MULTI_UPDATE_BATCH_SIZE, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_ITEM_UINT16   (FEATURE, LAMP_MULTI_UPDATE_BATCH_SIZE, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
         /* (Red, Green, Blue, Intensity) Slots */ \
         HID_REPEAT(LAMP_MULTI_UPDATE_BATCH_SIZE, \
             HID_USAGE       (HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL), \
@@ -153,13 +152,13 @@ struct __attribute__ ((packed)) LampAttributesResponseReport {
             HID_USAGE       (HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL), \
             HID_USAGE       (HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL), \
         ) \
-        HID_ITEM_UINT8    (OUTPUT, 4*LAMP_MULTI_UPDATE_BATCH_SIZE, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_ITEM_UINT8    (FEATURE, 4*LAMP_MULTI_UPDATE_BATCH_SIZE, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
     HID_COLLECTION_END
 
 struct __attribute__ ((packed)) LampMultiUpdateReport {
     uint8_t  lamp_count;
-    uint16_t update_flags;
-    uint8_t  lamp_ids[LAMP_MULTI_UPDATE_BATCH_SIZE];
+    uint8_t  update_flags;
+    uint16_t lamp_ids[LAMP_MULTI_UPDATE_BATCH_SIZE];
     uint8_t  rgbi_tuples[LAMP_MULTI_UPDATE_BATCH_SIZE][4];
 };
 
@@ -172,23 +171,23 @@ struct __attribute__ ((packed)) LampMultiUpdateReport {
     HID_COLLECTION  (HID_COLLECTION_LOGICAL), \
         /* LampUpdateFlags */ \
         HID_USAGE         (HID_USAGE_LIGHTING_LAMP_UPDATE_FLAGS), \
-        HID_ITEM_UINT16   (OUTPUT, 1, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_ITEM_UINT8    (FEATURE, 1, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
         /* LampIdStart, LampIdEnd */ \
         HID_USAGE         (HID_USAGE_LIGHTING_LAMP_ID_START), \
         HID_USAGE         (HID_USAGE_LIGHTING_LAMP_ID_END), \
-        HID_ITEM_UINT8    (OUTPUT, 2, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_ITEM_UINT16   (FEATURE, 2, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
         /* Red, Green, Blue, Intensity */ \
         HID_USAGE         (HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL), \
         HID_USAGE         (HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL), \
         HID_USAGE         (HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL), \
         HID_USAGE         (HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL), \
-        HID_ITEM_UINT8    (OUTPUT, 4, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_ITEM_UINT8    (FEATURE, 4, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
     HID_COLLECTION_END
 
 struct __attribute__ ((packed)) LampRangeUpdateReport {
-    uint16_t update_flags;
-    uint8_t  lamp_id_start;
-    uint8_t  lamp_id_end;
+    uint8_t  update_flags;
+    uint16_t lamp_id_start;
+    uint16_t lamp_id_end;
     uint8_t  rgbi_tuple[4];
 };
 
@@ -202,7 +201,11 @@ struct __attribute__ ((packed)) LampRangeUpdateReport {
     HID_COLLECTION  (HID_COLLECTION_LOGICAL), \
         /* AutonomousMode */ \
         HID_USAGE         (HID_USAGE_LIGHTING_AUTONOMOUS_MODE), \
-        HID_ITEM_UINT8    (FEATURE, 1, HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
+        HID_LOGICAL_MIN   (0), \
+        HID_LOGICAL_MAX   (1), \
+        HID_REPORT_SIZE   (8), \
+        HID_REPORT_COUNT  (1), \
+        HID_FEATURE       (HID_DATA | HID_VARIABLE | HID_ABSOLUTE), \
     HID_COLLECTION_END
 
 struct __attribute__ ((packed)) LampArrayControlReport {


### PR DESCRIPTION
The Windows 11 implementation of the Lighting & Illumination page apparently requires that devices report a descriptor that exactly matches the example given in the [original HUTRR84 proposal](https://www.usb.org/sites/default/files/hutrr84_-_lighting_and_illumination_page.pdf). When given a descriptor that does not match this example, the Windows APIs just hang, which is not very helpful for debugging.

While I think my implementation was largely correct given what the HID specs say, here's what I had to change:

* Always use feature reports, do not mix in output reports
* Use 16 bits for `LampId` usages
* Use 8 bits for `LampUpdateFlags` usages
* Fix the maximum value of the `AutonomousMode` usage
* Mark the lamp ID usage of the `LampAttributesRequestReport` as data
* Redefine the minimum value with each usage

I tried a few combinations of these fixes and saw the hang behavior every time, so my conclusion for now is that they are all required. The only change that seems acceptable is the number of lamps that can be updated in a `LampMultiUpdateReport`.

Fixes #2.

⚠️ **Because the CLI uses raw reports, it won't work until updated for the new report format.** ⚠️ 